### PR TITLE
Add front matter to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,3 +1,8 @@
+---
+name: 🐞 Bug Report
+about: Report a bug in this repo
+---
+
 <!--
 Please consider including the answers below when relevant:
 

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,3 +1,8 @@
+---
+name: 🧠 Feature Request
+about: Suggest an idea for improving this repo
+---
+
 <!--
 Please provide some context on what problem you are trying to solve and how this feature is going to help.
 


### PR DESCRIPTION
Almost positive this is needed for them to be recognized as issue templates.