### PR TITLE
Ignore empty templates during validation

### DIFF
--- a/.github/workflows/test-helpers/get-issue-validation-log
+++ b/.github/workflows/test-helpers/get-issue-validation-log
@@ -61,6 +61,6 @@ function backoff {
 echo "Downloading and extracting the validation workflow run log for issue #$1."
 backoff download-and-extract "$1"
 echo "Log downloaded and extracted successfully."
-echo "::group::log"
+echo "::group::Log:"
 cat log
 echo "::endgroup::"

--- a/.github/workflows/validate-new-issue-test.yml
+++ b/.github/workflows/validate-new-issue-test.yml
@@ -17,6 +17,7 @@ jobs:
           )
         )
         .github/workflows/test-helpers/get-issue-validation-log "${issue_number}"
+        set -x
         grep "Skipping validation" log
   case_2:
     name: "It runs non-member issues through validation."
@@ -55,8 +56,9 @@ jobs:
       run: |
         issue_number="${{ steps.setup.outputs.issue_number }}"
         .github/workflows/test-helpers/get-issue-validation-log "${issue_number}"
+        set -x
         grep "sentry-test-fixture-nonmember is not a member of the getsentry org." log
-        grep "BUG_REPORT.md? 👍 💃" log
+        grep "BUG_REPORT.md? Match! 👍 💃" log
   case_3:
     name: "It is flexible about header order and extra headers."
     runs-on: ubuntu-latest
@@ -85,4 +87,30 @@ jobs:
       run: |
         issue_number="${{ steps.setup.outputs.issue_number }}"
         .github/workflows/test-helpers/get-issue-validation-log "${issue_number}"
-        grep "BUG_REPORT.md? 👍 💃" log
+        set -x
+        grep "BUG_REPORT.md? Match! 👍 💃" log
+  case_4:
+    name: "It closes invalid issues with a comment."
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - id: setup
+      name: setup
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT_NONMEMBER }}
+      run: |
+        issue_number=$(
+          basename $(
+            gh issue create --title "Greetings, program!" \
+              --body "# Foo\nI don't follow directions."
+          )
+        )
+        echo "::set-output name=issue_number::${issue_number}"
+    - name: test
+      run: |
+        issue_number="${{ steps.setup.outputs.issue_number }}"
+        .github/workflows/test-helpers/get-issue-validation-log "${issue_number}"
+        set -x
+        grep 'BUG_REPORT.md? No match. 👎' log
+        grep 'FEATURE_REQUEST.md? No headers in template. 🤷' log
+        grep 'Commented: "https://github.com/${{ github.repository }}' log

--- a/.github/workflows/validate-new-issue.yml
+++ b/.github/workflows/validate-new-issue.yml
@@ -26,16 +26,18 @@ jobs:
         # - extra headings in the issue are fine
         # - order doesn't matter
         # - case-sensitive tho
-        function extract-headings { grep '^#' "$1" | sort; }
+        function extract-headings { { grep '^#' "$1" || echo -n ''; } | sort; }
         extract-headings <(jq -r .issue.body "$GITHUB_EVENT_PATH") > headings-in-issue
         for template in $(ls .github/ISSUE_TEMPLATE/*.md 2> /dev/null); do
-          echo -n "$(basename $template)? "
           extract-headings "$template" > headings-in-template
-          if [ -z "$(comm -23 headings-in-template headings-in-issue)" ]; then
-            echo "👍 💃"
+          echo -n "$(basename $template)? "
+          if [ ! -s headings-in-template ]; then
+            echo "No headers in template. 🤷"
+          elif [ -z "$(comm -23 headings-in-template headings-in-issue)" ]; then
+            echo "Match! 👍 💃"
             exit 0
           else
-            echo "👎"
+            echo "No match. 👎"
           fi
         done
 


### PR DESCRIPTION
Part of https://github.com/getsentry/.github/issues/26.

- Adds a test for the primary case: closing invalid issues.
- Fixes bug where we were never rejecting any issues because the headings-less `FEATURE_REQUEST.md` template would always match.
- Futzes with log futzing a bit (larger discussion re: testing strategy noted at https://github.com/getsentry/.github/issues/22#issuecomment-769933913).