### PR TITLE
gha(validation): Make room for other validations

### DIFF
--- a/.github/workflows/test-helpers/get-issue-validation-log
+++ b/.github/workflows/test-helpers/get-issue-validation-log
@@ -27,7 +27,7 @@ function download-and-extract {
     return 1
   fi
   echo "Extracting validation log ..."
-  logfile="validate-new-issue/3_Validate issue against templates.txt"
+  logfile="validate-new-issue/3_Validate new issue.txt"
   unzip log.zip "$logfile"
   # Strip initial echo of whole run body. https://unix.stackexchange.com/a/218144
   { sed -ne'/##\[endgroup]/q;H;1h;$!d;x;p'; cat; } < "$logfile" > log

--- a/.github/workflows/test-helpers/get-issue-validation-log
+++ b/.github/workflows/test-helpers/get-issue-validation-log
@@ -39,7 +39,7 @@ function download-and-extract {
   actual=$(grep 'Validating issue #[0-9]*\.[^"]' log | sed -Ee 's/.*#([0-9]*)\..*/\1/')
   echo "Expected: ${expected}"
   echo "Actual:   ${actual}"
-  test $actual = $expected
+  test "$actual" = "$expected"
 }
 
 function backoff {

--- a/.github/workflows/validate-new-issue-test.yml
+++ b/.github/workflows/validate-new-issue-test.yml
@@ -117,6 +117,7 @@ jobs:
           grep 'BUG_REPORT.md? No match. 👎' log
           grep 'FEATURE_REQUEST.md? No headers in template. 🤷' log
           grep 'Commented: https://github.com/${{ github.repository }}' log
+          grep "Closed with: .* does not properly use" log
   case_5:
     name: "It considers exact matches to be invalid."
     needs: case_4
@@ -142,7 +143,7 @@ jobs:
           set -x
           grep "BUG_REPORT.md? Match! 👍 💃" log
           grep "... like, an /exact/ match. 😖" log
-          grep 'Commented: https://github.com/${{ github.repository }}' log
+          grep "Closed with: .* without filling in anything" log
   case_6:
     name: "It doesn't care about CRLF line endings."
     needs: case_5
@@ -166,6 +167,4 @@ jobs:
           issue_number="${{ steps.setup.outputs.issue_number }}"
           .github/workflows/test-helpers/get-issue-validation-log "${issue_number}"
           set -x
-          grep "BUG_REPORT.md? Match! 👍 💃" log
-          grep "... like, an /exact/ match. 😖" log
-          grep 'Commented: https://github.com/${{ github.repository }}' log
+          grep "Closed with: .* without filling in anything" log

--- a/.github/workflows/validate-new-issue-test.yml
+++ b/.github/workflows/validate-new-issue-test.yml
@@ -105,7 +105,7 @@ jobs:
           issue_number=$(
             basename $(
               gh issue create --title "Greetings, program!" \
-                --body "# Foo\nI don't follow directions."
+                --body "I don't follow directions."
             )
           )
           echo "::set-output name=issue_number::${issue_number}"

--- a/.github/workflows/validate-new-issue.yml
+++ b/.github/workflows/validate-new-issue.yml
@@ -56,7 +56,9 @@ jobs:
 
           ----
 
-          [![Did you see the memo about this?](https://user-images.githubusercontent.com/134455/104515469-e04a9c80-55c0-11eb-8e15-ffe9c0b8dd7f.gif)](https://www.youtube.com/watch?v=Fy3rjQGc6lA)"
+          [![Did you see the memo about this?](https://user-images.githubusercontent.com/134455/104515469-e04a9c80-55c0-11eb-8e15-ffe9c0b8dd7f.gif)](https://www.youtube.com/watch?v=Fy3rjQGc6lA)
+
+          ([log](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}))
           EOF
 
           echo -n "Commented: "

--- a/.github/workflows/validate-new-issue.yml
+++ b/.github/workflows/validate-new-issue.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: "Validate issue against templates"
+      - name: "Validate new issue"
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -22,11 +22,17 @@ jobs:
             echo "${{ github.actor }} is not a member of the getsentry org. 🧐"
           fi
 
-          # Look for a template where all the headings are also in this issue.
-          # - extra headings in the issue are fine
-          # - order doesn't matter
-          # - case-sensitive tho
-          # - can't post a template unchanged (ignoring whitespace)
+          # Prep reasons for error message comment.
+          REASON="your issue does not properly use one of this repo's available issue templates"
+          REASON_EXACT_MATCH="you created an issue from a template without filling in anything"
+
+          # Definition of valid:
+          # - matches a template
+          #   - all the headings are also in this issue
+          #   - extra headings in the issue are fine
+          #   - order doesn't matter
+          #   - case-sensitive tho
+          # - not an *exact* match for a template (ignoring whitespace)
           function extract-headings { { sed 's/\r$//' "$1" | grep '^#' || echo -n ''; } | sort; }
           jq -r .issue.body "$GITHUB_EVENT_PATH" > issue
           extract-headings <(cat issue) > headings-in-issue
@@ -41,6 +47,7 @@ jobs:
               echo "Match! 👍 💃"
               if diff -Bw "$template" issue > /dev/null; then
                 echo "... like, an /exact/ match. 😖"
+                REASON="${REASON_EXACT_MATCH}"
                 break
               else
                 exit 0
@@ -50,9 +57,9 @@ jobs:
             fi
           done
 
-          # Failed to find a match! Close the issue.
+          # Failed validation! Close the issue with a comment.
           cat << EOF > comment
-          Sorry, friend. As far as this ol' bot can tell, your issue does not use one of this repo's available issue templates. Please [try again using a template](https://github.com/${{ github.repository }}/issues/new/choose) so that we have the best chance of understanding and addressing your issue. (And if I'm confused, please [let us know](https://github.com/getsentry/.github/issues/new?title=template+enforcer+is+confused&body=${{ github.event.issue.html_url }}). 😬)
+          Sorry, friend. As far as this ol' bot can tell, ${REASON}. Please [try again](https://github.com/${{ github.repository }}/issues/new/choose), if you like. (And if I'm confused, please [let us know](https://github.com/getsentry/.github/issues/new?title=template+enforcer+is+confused&body=${{ github.event.issue.html_url }}). 😬)
 
           ----
 
@@ -64,3 +71,4 @@ jobs:
           echo -n "Commented: "
           gh issue comment ${{ github.event.issue.number }} --body "$(cat comment)"
           gh issue close ${{ github.event.issue.number }}
+          echo "Closed with: \"${REASON}.\""


### PR DESCRIPTION
- Broaden scope of action slightly to be about validation in general, not just validation against a template (makes room for rejecting entirely empty issues).
- Adds link back to logs for visibility and easier debugging.
- Picks off a few nits in the process.