### PR TITLE
ref(validation): Relax validation bot

### DIFF
--- a/.github/workflows/validate-new-issue-test.yml
+++ b/.github/workflows/validate-new-issue-test.yml
@@ -181,3 +181,24 @@ jobs:
           set -x
           test "$(cat issue-state)" = "open"
           test "$(cat issue-ncomments)" = "0"
+  case_10:
+    name: "It doesn't require all headers to match"
+    needs: case_9
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: setup
+        name: setup
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_NONMEMBER }}
+        run: |
+          .github/workflows/test-helpers/make-issue "
+          ### Steps to Reproduce
+          ### Expected Result
+          ### Actual Result
+          "
+      - name: test
+        run: |
+          set -x
+          test "$(cat issue-state)" = "open"
+          test "$(cat issue-ncomments)" = "0"

--- a/.github/workflows/validate-new-issue.yml
+++ b/.github/workflows/validate-new-issue.yml
@@ -41,7 +41,7 @@ jobs:
           # - is a report about buggy validation 😅 or ...
           # - not empty (ignoring whitespace)
           # - matches a template
-          #   - all the headings are also in this issue
+          #   - at least one of the headings are also in this issue
           #   - extra headings in the issue are fine
           #   - order doesn't matter
           #   - case-sensitive tho
@@ -66,7 +66,7 @@ jobs:
               echo -n "$(basename $template)? "
               if [ ! -s headings-in-template ]; then
                 echo "No headers in template. 🤷"
-              elif [ -z "$(comm -23 headings-in-template headings-in-issue)" ]; then
+              elif [ "$(comm -12 headings-in-template headings-in-issue)" ]; then
                 echo "Match! 👍 💃"
                 if diff -Bw "$template" issue > /dev/null; then
                   echo "... like, an /exact/ match. 😖"


### PR DESCRIPTION
Fixes #62.

Relaxes validation bot to only look for a single matching header instead of all headers in the template.
