### PR TITLE
feat(router): Ignore triaged issues

### DIFF
--- a/.github/workflows/issue-routing-helper.yml
+++ b/.github/workflows/issue-routing-helper.yml
@@ -9,7 +9,12 @@ env:
 jobs:
   route:
     runs-on: ubuntu-latest
-    if: "startsWith(github.event.label.name, 'Team: ')"
+    if: >-
+      startsWith(github.event.label.name, 'Team: ')
+      &&
+      !contains(github.event.issue.labels.*.name, 'Status: Accepted')
+      &&
+      !contains(github.event.issue.labels.*.name, 'Status: In Progress')
     steps:
       - name: "Ensure a single 'Team: *' label with 'Status: Untriaged'"
         run: |

--- a/.github/workflows/issue-routing-helper.yml
+++ b/.github/workflows/issue-routing-helper.yml
@@ -12,7 +12,7 @@ jobs:
     if: >-
       startsWith(github.event.label.name, 'Team: ')
       &&
-      !contains(github.event.issue.labels.*.name, 'Status: Accepted')
+      !contains(github.event.issue.labels.*.name, 'Status: Backlog')
       &&
       !contains(github.event.issue.labels.*.name, 'Status: In Progress')
     steps:


### PR DESCRIPTION
Fixes #68 by ignoring issues that already have `Status: Backlog` or `Status: In Progress` label when routing. Note that this also skips the `@team` mention comment.
