### PR TITLE
Ignore closed issues in routing helper

### DIFF
--- a/.github/workflows/issue-routing-helper.yml
+++ b/.github/workflows/issue-routing-helper.yml
@@ -10,6 +10,8 @@ jobs:
   route:
     runs-on: ubuntu-latest
     if: >-
+      github.event.issue.state == 'open'
+      &&
       startsWith(github.event.label.name, 'Team: ')
       &&
       !contains(github.event.issue.labels.*.name, 'Status: Backlog')


### PR DESCRIPTION
Fixes #72.

Untested as promised, @BYK.

(Tested manually though: [labeled](https://github.com/getsentry/.github-chadwhitacre/issues/695#event-5124482871), [skipped](https://github.com/getsentry/.github-chadwhitacre/runs/3265396317?check_suite_focus=true)).