### PR TITLE
Improve error handling around gh api

### DIFF
--- a/.github/workflows/issue-routing-helper.yml
+++ b/.github/workflows/issue-routing-helper.yml
@@ -19,9 +19,12 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'Status: In Progress')
     steps:
       - name: "Ensure a single 'Team: *' label with 'Status: Untriaged'"
+        env:
+          team_label: ${{ github.event.label.name }}
+          issue_number: ${{ github.event.issue.number }}
         run: |
-          labels_to_remove=$(gh api --paginate "/repos/$GH_REPO/labels" -q '[.[].name | select((startswith("Team: ") or startswith("Status: ")) and . != "${{ github.event.label.name }}" and . != "Status: Untriaged")] | join(",")')
-          gh issue edit ${{ github.event.issue.number }} --remove-label "$labels_to_remove" --add-label '${{ github.event.label.name }},Status: Untriaged'
+          labels_to_remove="$(gh api --paginate "/repos/$GH_REPO/labels" | jq -r --arg label_name "$team_label" '[.[].name | select((startswith("Team: ") or startswith("Status: ")) and . != $label_name and . != "Status: Untriaged")] | join(",")')
+          gh issue edit "$issue_number" --remove-label "$labels_to_remove" --add-label "${team_label},Status: Untriaged"
       - name: "Mention/ping assigned team for triage"
         env:
           team_label: ${{ github.event.label.name }}

--- a/.github/workflows/issue-routing-helper.yml
+++ b/.github/workflows/issue-routing-helper.yml
@@ -23,23 +23,21 @@ jobs:
           labels_to_remove=$(gh api --paginate "/repos/$GH_REPO/labels" -q '[.[].name | select((startswith("Team: ") or startswith("Status: ")) and . != "${{ github.event.label.name }}" and . != "Status: Untriaged")] | join(",")')
           gh issue edit ${{ github.event.issue.number }} --remove-label "$labels_to_remove" --add-label '${{ github.event.label.name }},Status: Untriaged'
       - name: "Mention/ping assigned team for triage"
+        env:
+          team_label: ${{ github.event.label.name }}
+          issue_number: ${{ github.event.issue.number }}
         run: |
           # Get team label mention name:
-          team_label='${{ github.event.label.name }}'
           team_name="${team_label:6}" # Strip the first 6 chars, which is the 'Team: ' part
           team_slug="${team_name// /-}" # Replace spaces with hyphens for url/slug friendliness
-          mention_slug=$(gh api "/orgs/getsentry/teams/$team_slug" -q .slug || true)
-          if [ "${mention_slug::1}" = "{" ]; then
-            # Hack around https://github.com/getsentry/.github/issues/77
+          if ! mention_slug="$(gh api "/orgs/getsentry/teams/$team_slug" -q .slug)"; then
             mention_slug=""
           fi
 
           if [[ -z "$mention_slug" ]]; then
             echo "Couldn't find team mention from slug, trying the label description"
-            team_slug=$(gh api "/repos/$GH_REPO/labels/$team_label" -q '.description')
-            mention_slug=$(gh api "/orgs/getsentry/teams/$team_slug" -q .slug || true)
-            if [ "${mention_slug::1}" = "{" ]; then
-              # Hack around https://github.com/getsentry/.github/issues/77
+            team_slug="$(gh api "/repos/$GH_REPO/labels/$team_label" -q '.description')"
+            if ! mention_slug="$(gh api "/orgs/getsentry/teams/$team_slug" -q .slug)"; then
               mention_slug=""
             fi
           fi
@@ -47,8 +45,8 @@ jobs:
           if [[ -n "$mention_slug" ]]; then
             echo "Routing to @getsentry/$mention_slug for [triage](https://develop.sentry.dev/processing-tickets/#3-triage). ⏲️" > comment_body
           else
-            echo "[Failed]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) to route to \`${{ github.event.label.name }}\`.  😕" > comment_body
+            echo "[Failed]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) to route to \`$team_label\`.  😕" > comment_body
             echo "" >> comment_body
             echo "Defaulting to @getsentry/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage). ⏲️" >> comment_body
           fi
-          gh issue comment ${{ github.event.issue.number }} --body-file comment_body
+          gh issue comment "$issue_number" --body-file comment_body


### PR DESCRIPTION
Explicitly handle error statuses from `gh api` instead of detecting error conditions by inspecting the first character of the output. It is not guaranteed that the first character of an errored `gh api` response is `{`, but it's definitely guaranteed that in case of HTTP 4xx–5xx responses, `gh api` will exit with a nonzero status. This approaches uses the failing status to blank out the `mention_slug` variable, which I find to be less hacky and more future-proof.

Additionally, this avoids GitHub Actions workflow interpolation `${{...}}` embedded in bash script and instead passes in variables as environment variables. The bash script may fail after expanding these placeholders if any of the expanded value contains characters like `"'${}!` or similar characters that have special meaning in bash. Passing in environment variables, on the other hand, is safe regardless of the value.

Followup to https://github.com/getsentry/.github/pull/78. Untested. Feel free to discard ✌️ /cc @chadwhitacre 

Ref. https://github.com/cli/cli/issues/5209