### PR TITLE
Remove SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,1 +1,0 @@
-If you are using [sentry.io](https://sentry.io), the SaaS product, please visit [sentry.io/support](https://sentry.io/support) for any support needs. If you are using the open source version, you can use our [community forums](https://github.com/getsentry/sentry/discussions) or the public [Discord Server](https://discord.gg/6c52wN7).


### PR DESCRIPTION
Follow-up to #100, where I learned about this file. :P

Now that we have a process in place for [routing and triaging](https://open.sentry.io/triage/) GitHub Issues, I think we can remove this file, the purpose of which is to [put a little help text prompt](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project) when people are opening new GitHub issues. We used to want people to not open issues with us but now we want them to.

Thoughts @drguthals @souredoutlook?

<img width="1192" alt="Screen Shot 2022-06-21 at 5 50 36 PM" src="https://user-images.githubusercontent.com/134455/174903057-23437ed4-bb9d-4838-805e-c7a703f31de3.png">

