### PR TITLE
Utilize GitHub's private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+
+
+# Security
+
+## Reporting Security Issues
+
+If you've found a security issue in Sentry or in our supported SDKs, please report the issue to `security[@]sentry.io`.
+
+Please include as much information as possible in your report to better help us understand and resolve the issue: 
+
+- Where the security issues exists (ie. Sentry SaaS, a Sentry-supported SDK, infrastructure, etc.)
+- The type of issue (ex. SQL injection, cross-site scripting, missing authorization, etc.)
+- Full paths or links to the source files where the security issue exists, if possible
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof of concept or exploit code, if available
+
+If you need to encrypt sensitive information sent to us, please use [our PGP key](https://pgp.mit.edu/pks/lookup?op=vindex&search=0x641D2F6C230DBE3B): 
+
+```
+E406 C27A E971 6515 A1B1 ED86 641D 2F6C 230D BE3B
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,12 @@
 
 ## Reporting Security Issues
 
-If you've found a security issue in Sentry or in our supported SDKs, please report the issue to `security[@]sentry.io`.
+If you've found a security issue in Sentry or in our supported SDKs, you can submit your report with one of the options below.
+
+1. Using [GitHub's private vulnerabilty reporting feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) on the corresponding repository.
+2. Via email to `security[@]sentry.io`.
+
+> We prefer reports via GitHub's private vulnerability reporting.
 
 Please include as much information as possible in your report to better help us understand and resolve the issue: 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,3 @@
-
-
 # Security
 
 ## Reporting Security Issues

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you've found a security issue in Sentry or in our supported SDKs, please repo
 
 Please include as much information as possible in your report to better help us understand and resolve the issue: 
 
-- Where the security issues exists (ie. Sentry SaaS, a Sentry-supported SDK, infrastructure, etc.)
+- Where the security issue exists (ie. Sentry SaaS, a Sentry-supported SDK, infrastructure, etc.)
 - The type of issue (ex. SQL injection, cross-site scripting, missing authorization, etc.)
 - Full paths or links to the source files where the security issue exists, if possible
 - Any special configuration required to reproduce the issue


### PR DESCRIPTION
Adjusts our standard SECURITY.md policy to suggest reporting vulnerabilities via [GitHub's new feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).