### PR TITLE
Check for sentry member/owner for issue author before introducing routing logic

### DIFF
--- a/.github/workflows/issue-routing-helper.yml
+++ b/.github/workflows/issue-routing-helper.yml
@@ -18,6 +18,15 @@ jobs:
       &&
       !contains(github.event.issue.labels.*.name, 'Status: In Progress')
     steps:
+      - name: "Check to make sure issue creator is not a Sentry org member"
+        env:
+          issue_number: ${{ github.event.issue.number }}
+        run: |
+          author_association=$(gh api "repos/$GH_REPO/issues/$issue_number" -q .author_association)
+          if [[ "$author_association" = "MEMBER" || "$author_association" = "OWNER" ]]; then
+            echo "Skipping routing logic since issue is opened by a Sentry org member."
+            exit 0
+          fi
       - name: "Ensure a single 'Team: *' label with 'Status: Untriaged'"
         env:
           team_label: ${{ github.event.label.name }}

--- a/.github/workflows/issue-routing-helper.yml
+++ b/.github/workflows/issue-routing-helper.yml
@@ -18,38 +18,51 @@ jobs:
       &&
       !contains(github.event.issue.labels.*.name, 'Status: In Progress')
     steps:
-      - name: "Check to make sure issue creator is not a Sentry org member"
+      - name: "Check Membership of issue creator"
+        id: "check_membership"
         env:
           issue_number: ${{ github.event.issue.number }}
         run: |
           author_association=$(gh api "repos/$GH_REPO/issues/$issue_number" -q .author_association)
-          if [[ "$author_association" = "MEMBER" || "$author_association" = "OWNER" ]]; then
-            echo "Skipping routing logic since issue is opened by a Sentry org member."
-            exit 0
-          fi
+          echo "membership=$author_association" >> $GITHUB_OUTPUT
       - name: "Ensure a single 'Team: *' label with 'Status: Untriaged'"
         env:
           team_label: ${{ github.event.label.name }}
           issue_number: ${{ github.event.issue.number }}
+          membership: ${{ steps.check_membership.outputs.membership }}
+        if: >-
+          env.membership != 'OWNER'
+          &&
+          env.membership != 'MEMBER'
         run: |
-          labels_to_remove="$(gh api --paginate "/repos/$GH_REPO/labels" | jq -r --arg label_name "$team_label" '[.[].name | select((startswith("Team: ") or startswith("Status: ")) and . != $label_name and . != "Status: Untriaged")] | join(",")')
-          gh issue edit "$issue_number" --remove-label "$labels_to_remove" --add-label "${team_label},Status: Untriaged"
+          labels_to_remove=$(gh api --paginate "/repos/$GH_REPO/labels" -q '[.[].name | select((startswith("Team: ") or startswith("Status: ")) and . != "${{ github.event.label.name }}" and . != "Status: Untriaged")] | join(",")')
+          gh issue edit ${{ github.event.issue.number }} --remove-label "$labels_to_remove" --add-label '${{ github.event.label.name }},Status: Untriaged'
       - name: "Mention/ping assigned team for triage"
         env:
           team_label: ${{ github.event.label.name }}
           issue_number: ${{ github.event.issue.number }}
+          membership: ${{ steps.check_membership.outputs.membership }}
+        if: >-
+          env.membership != 'OWNER'
+          &&
+          env.membership != 'MEMBER'
         run: |
           # Get team label mention name:
+          team_label='${{ github.event.label.name }}'
           team_name="${team_label:6}" # Strip the first 6 chars, which is the 'Team: ' part
           team_slug="${team_name// /-}" # Replace spaces with hyphens for url/slug friendliness
-          if ! mention_slug="$(gh api "/orgs/getsentry/teams/$team_slug" -q .slug)"; then
+          mention_slug=$(gh api "/orgs/getsentry/teams/$team_slug" -q .slug || true)
+          if [ "${mention_slug::1}" = "{" ]; then
+            # Hack around https://github.com/getsentry/.github/issues/77
             mention_slug=""
           fi
 
           if [[ -z "$mention_slug" ]]; then
             echo "Couldn't find team mention from slug, trying the label description"
-            team_slug="$(gh api "/repos/$GH_REPO/labels/$team_label" -q '.description')"
-            if ! mention_slug="$(gh api "/orgs/getsentry/teams/$team_slug" -q .slug)"; then
+            team_slug=$(gh api "/repos/$GH_REPO/labels/$team_label" -q '.description')
+            mention_slug=$(gh api "/orgs/getsentry/teams/$team_slug" -q .slug || true)
+            if [ "${mention_slug::1}" = "{" ]; then
+              # Hack around https://github.com/getsentry/.github/issues/77
               mention_slug=""
             fi
           fi
@@ -57,8 +70,8 @@ jobs:
           if [[ -n "$mention_slug" ]]; then
             echo "Routing to @getsentry/$mention_slug for [triage](https://develop.sentry.dev/processing-tickets/#3-triage). ⏲️" > comment_body
           else
-            echo "[Failed]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) to route to \`$team_label\`.  😕" > comment_body
+            echo "[Failed]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) to route to \`${{ github.event.label.name }}\`.  😕" > comment_body
             echo "" >> comment_body
             echo "Defaulting to @getsentry/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage). ⏲️" >> comment_body
           fi
-          gh issue comment "$issue_number" --body-file comment_body
+          gh issue comment ${{ github.event.issue.number }} --body-file comment_body


### PR DESCRIPTION
Fixes the issue for github actions where issues opened by sentry members are still getting routed.

https://github.com/getsentry/eng-pipes/issues/355