### PR TITLE
removed instructions to use gh's private reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,11 @@
 
 ## Reporting Security Issues
 
-If you've found a security issue in Sentry or in our supported SDKs, you can submit your report with one of the options below.
-
-1. Using [GitHub's private vulnerabilty reporting feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) on the corresponding repository.
-2. Via email to `security[@]sentry.io`.
+If you've found a security issue in Sentry or in our supported SDKs, you can submit your report to `security[@]sentry.io` via email.
 
 > We prefer reports via GitHub's private vulnerability reporting.
 
-Please include as much information as possible in your report to better help us understand and resolve the issue: 
+Please include as much information as possible in your report to better help us understand and resolve the issue:
 
 - Where the security issue exists (ie. Sentry SaaS, a Sentry-supported SDK, infrastructure, etc.)
 - The type of issue (ex. SQL injection, cross-site scripting, missing authorization, etc.)
@@ -18,7 +15,7 @@ Please include as much information as possible in your report to better help us 
 - Step-by-step instructions to reproduce the issue
 - Proof of concept or exploit code, if available
 
-If you need to encrypt sensitive information sent to us, please use [our PGP key](https://pgp.mit.edu/pks/lookup?op=vindex&search=0x641D2F6C230DBE3B): 
+If you need to encrypt sensitive information sent to us, please use [our PGP key](https://pgp.mit.edu/pks/lookup?op=vindex&search=0x641D2F6C230DBE3B):
 
 ```
 E406 C27A E971 6515 A1B1 ED86 641D 2F6C 230D BE3B


### PR DESCRIPTION
The private reporting feature could still use some work, so I'd like to not _officially_ recommend it in our security policy. 