### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,6 @@
 
 If you've found a security issue in Sentry or in our supported SDKs, you can submit your report to `security[@]sentry.io` via email.
 
-> We prefer reports via GitHub's private vulnerability reporting.
-
 Please include as much information as possible in your report to better help us understand and resolve the issue:
 
 - Where the security issue exists (ie. Sentry SaaS, a Sentry-supported SDK, infrastructure, etc.)


### PR DESCRIPTION
Removing note about preference for github's private security reporting.
I must have missed this in the previous PR. 🙃 https://github.com/getsentry/.github/pull/110