### PR TITLE
security: org-wide secret scanning

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,73 @@
+name: Secret Scan
+
+on: [pull_request]
+
+jobs:
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+
+    outputs:
+      branch: ${{ steps.fetch_depth.outputs.branch }}
+      depth: ${{ steps.fetch_depth.outputs.depth }}
+      latest_release: ${{ steps.trufflehog_release.outputs.latest_release }}
+      latest_tag_name: ${{ steps.trufflehog_release.outputs.latest_tag_name }}
+
+    steps:
+      - name: Set fetch depth
+        id: fetch_depth
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "depth=$(($(jq length <<< '${{ toJson(github.event.commits) }}') + 2))" >> "$GITHUB_OUTPUT"
+            echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "depth=$((${{ github.event.pull_request.commits }}+2))" >> "$GITHUB_OUTPUT"
+            echo "branch=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.fetch_depth.outputs.branch }}
+          fetch-depth: ${{ steps.fetch_depth.outputs.depth }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Get latest TruffleHog release
+        id: trufflehog_release
+        shell: bash
+        run: |
+          LATEST_TAG_NAME=$(curl -s https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest | jq -r .name)
+          LATEST_RELEASE=$(echo ${LATEST_TAG_NAME:1})
+          echo "latest_tag_name=$LATEST_TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "latest_release=$LATEST_RELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Download and verify TruffleHog release
+        run: |
+          curl -sLO https://github.com/trufflesecurity/trufflehog/releases/download/${{ steps.trufflehog_release.outputs.latest_tag_name }}/trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt
+          curl -sLO https://github.com/trufflesecurity/trufflehog/releases/download/${{ steps.trufflehog_release.outputs.latest_tag_name }}/trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt.pem
+          curl -sLO https://github.com/trufflesecurity/trufflehog/releases/download/${{ steps.trufflehog_release.outputs.latest_tag_name }}/trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt.sig
+          curl -sLO https://github.com/trufflesecurity/trufflehog/releases/download/${{ steps.trufflehog_release.outputs.latest_tag_name }}/trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_linux_amd64.tar.gz
+
+          cosign verify-blob trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt \
+            --certificate trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt.pem \
+            --signature trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt.sig \
+            --certificate-identity-regexp 'https://github\.com/trufflesecurity/trufflehog/\.github/workflows/.+' \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+          sha256sum --ignore-missing -c trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt 
+
+
+      - name: Extract TruffleHog
+        run: |
+          tar xzf trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_linux_amd64.tar.gz -C /usr/local/bin
+          chmod +x /usr/local/bin/trufflehog
+
+      - name: Run TruffleHog scan
+        run: |
+          trufflehog git file://. --only-verified --github-actions --fail


### PR DESCRIPTION
Sentry uses GH's Secret Scanning on our public repositories, including their push protection to prevent secret leaks.

However, this does not cover private repositories without an expensive GHAS license. With this org-wide workflow, this will ensure secret scanning occurs on pull requests whether they're in a private or public repository. 

This workflow does not pull the full commit history but just the current default branch + 2 commit to make sure scanning stays speedy. As a result, this won't detect secrets already committed to private repos, but we're working through any of those in a separate work stream.