### PR TITLE
fix(secret scanner): Exclude datadog detector

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run TruffleHog scan
         run: |
           if [ -e .secret_scan_ignore ]; then
-            trufflehog git file://. --only-verified --github-actions --fail --exclude-paths=.secret_scan_ignore
+            trufflehog git file://. --only-verified --github-actions --fail --exclude-paths=.secret_scan_ignore --exclude-detectors="datadogtoken"
           else
-            trufflehog git file://. --only-verified --github-actions --fail
+            trufflehog git file://. --only-verified --github-actions --fail --exclude-detectors="datadogtoken"
           fi


### PR DESCRIPTION
Most of the Datadog secrets that are flagged are the DSN-like tokens that do not have access to anything other than collecting data.
Excluding the detector to reduce noises. 