### PR TITLE
ci(trufflehog): bump to 3.80.3

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -29,8 +29,8 @@ jobs:
         #   echo "latest_tag_name=$LATEST_TAG_NAME" >> "$GITHUB_OUTPUT"
         #   echo "latest_release=$LATEST_RELEASE" >> "$GITHUB_OUTPUT"
         run: |
-          echo "latest_tag_name=v3.79.0" >> "$GITHUB_OUTPUT"
-          echo "latest_release=3.79.0" >> "$GITHUB_OUTPUT"
+          echo "latest_tag_name=v3.80.3" >> "$GITHUB_OUTPUT"
+          echo "latest_release=3.80.3" >> "$GITHUB_OUTPUT"
 
       - name: Download and verify TruffleHog release
         run: |


### PR DESCRIPTION
Bumps TruffleHog to the latest version.