### PR TITLE
add custom dependency review configuration

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,7 @@
+fail-on-severity: 'high'
+allow-ghsas:
+  # dependency review does not allow specific file exclusions
+  # we use an older version of NextJS in our tests and thus need to 
+  # exclude this
+  # once our minimum supported version is over 14.1.1 this can be removed
+  - GHSA-fr5h-rqp8-mj6g

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,8 +11,23 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Dependency Review
+      - name: 'Check Config'
+        id: check_config
+        run: |
+          if [ -f .github/dependency-review-config.yml ]; then
+            echo "dependency_review_config_exists=true" >> $GITHUB_ENV
+          else
+            echo "dependency_review_config_exists=false" >> $GITHUB_ENV
+          fi
+
+      - name: Dependency Review (local config)
+        if: env.dependency_review_config_exists == 'true'
         uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4
         with:
-          # Possible values: "critical", "high", "moderate", "low"
-          fail-on-severity: high 
+          config-file: './.github/dependency-review-config.yml'
+
+      - name: Dependency Review
+        if: env.dependency_review_config_exists == 'false'
+        uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
Our tests need to support older versions of libraries. In this case there's a vulnerable version of NextJS in the tests that is failing the Dependency Review check.

This adds a configuration file that allows us to specifically exclude the vulnerable finding at least until our minimum supported NextJS version is >= 14.1.1 or GitHub adds support for excluding specific directories from dependency review.