### PR TITLE
Add quotes to status value for results delivery

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -45,8 +45,7 @@ jobs:
             --certificate-identity-regexp 'https://github\.com/trufflesecurity/trufflehog/\.github/workflows/.+' \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 
-          sha256sum --ignore-missing -c trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt 
-
+          sha256sum --ignore-missing -c trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt
 
       - name: Extract TruffleHog
         run: |
@@ -67,7 +66,7 @@ jobs:
         run: |
           curl "${{vars.SECRET_SCAN_PANTHER_WEBHOOK_URL}}" \
             --header "Authorization: Bearer ${{ secrets.SECRET_SCAN_PANTHER_WEBHOOK_HEADER }}" \
-            --data '{"event":"github_secret_scanning", "status":${{steps.scan.outcome}}, "createdAt":"${{ github.event.pull_request.created_at }}", "repo":"${{ github.repository }}","pull_request":"https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}","actor":"${{ github.event.pull_request.user.login }}"}'
+            --data '{"event":"github_secret_scanning", "status":"${{steps.scan.outcome}}", "createdAt":"${{ github.event.pull_request.created_at }}", "repo":"${{ github.repository }}","pull_request":"https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}","actor":"${{ github.event.pull_request.user.login }}"}'
       - name: Fail workflow if secret detected
         if: steps.scan.outcome != 'success'
         run: exit 1


### PR DESCRIPTION
Whoops, I missed this in my review of https://github.com/getsentry/.github/pull/146. Value of status needs to be quoted.

Currently the log looks like:
```
{"event":"github_secret_scanning", "status":success, "createdAt":"2024-10-30T17:11:19Z", "repo":"getsentry/sentry","pull_request":"https://github.com/getsentry/sentry/pull/79995","actor":"some.user"}
```
And now it'll be
```
{"event":"github_secret_scanning", "status":"success", "createdAt":"2024-10-30T17:11:19Z", "repo":"getsentry/sentry","pull_request":"https://github.com/getsentry/sentry/pull/79995","actor":"some.user"}
```
