### PR TITLE
fix(secret-scan): skip curl if env var not available

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -64,9 +64,11 @@ jobs:
       - name: Send Alert to Panther
         id: alert
         run: |
-          curl "${{vars.SECRET_SCAN_PANTHER_WEBHOOK_URL}}" \
-            --header "Authorization: Bearer ${{ secrets.SECRET_SCAN_PANTHER_WEBHOOK_HEADER }}" \
-            --data '{"event":"github_secret_scanning", "status":"${{steps.scan.outcome}}", "createdAt":"${{ github.event.pull_request.created_at }}", "repo":"${{ github.repository }}","pull_request":"https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}","actor":"${{ github.event.pull_request.user.login }}"}'
+          if [[ -n "${{vars.SECRET_SCAN_PANTHER_WEBHOOK_URL}}" ]]; then
+            curl "${{vars.SECRET_SCAN_PANTHER_WEBHOOK_URL}}" \
+              --header "Authorization: Bearer ${{ secrets.SECRET_SCAN_PANTHER_WEBHOOK_HEADER }}" \
+              --data '{"event":"github_secret_scanning", "status":"${{steps.scan.outcome}}", "createdAt":"${{ github.event.pull_request.created_at }}", "repo":"${{ github.repository }}","pull_request":"https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}","actor":"${{ github.event.pull_request.user.login }}"}'
+          fi
       - name: Fail workflow if secret detected
         if: steps.scan.outcome != 'success'
         run: exit 1


### PR DESCRIPTION
Due to security design in GitHub, the `vars.SECRET_SCAN_PANTHER_WEBHOOK_URL` will not be exposed to outside collaborators who open PRs on our repos, which cause the secret scanner to fail.
Adding an if statement and do nothing if the var is not available.