### PR TITLE
INFO-643 Remove datadog exclusion

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -57,9 +57,9 @@ jobs:
         id: scan
         run: |
           if [ -e .secret_scan_ignore ]; then
-            trufflehog git file://. --only-verified --github-actions --fail --exclude-paths=.secret_scan_ignore --exclude-detectors="datadogtoken"
+            trufflehog git file://. --only-verified --github-actions --fail --exclude-paths=.secret_scan_ignore"
           else
-            trufflehog git file://. --only-verified --github-actions --fail --exclude-detectors="datadogtoken"
+            trufflehog git file://. --only-verified --github-actions --fail"
           fi
       - name: Send Alert to Panther
         id: alert


### PR DESCRIPTION
Per INC-874 and INFO-643, we're removing the datadog token exclusion from trufflehog scanning