### PR TITLE
chores(secret_scan): Update Trufflehog to latest version 

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -29,8 +29,8 @@ jobs:
         #   echo "latest_tag_name=$LATEST_TAG_NAME" >> "$GITHUB_OUTPUT"
         #   echo "latest_release=$LATEST_RELEASE" >> "$GITHUB_OUTPUT"
         run: |
-          echo "latest_tag_name=v3.82.13" >> "$GITHUB_OUTPUT"
-          echo "latest_release=3.82.13" >> "$GITHUB_OUTPUT"
+          echo "latest_tag_name=v3.88.11" >> "$GITHUB_OUTPUT"
+          echo "latest_release=3.88.11" >> "$GITHUB_OUTPUT"
 
       - name: Download and verify TruffleHog release
         run: |


### PR DESCRIPTION
Using [v3.88.11](https://github.com/trufflesecurity/trufflehog/releases/tag/v3.88.11) now, this will add support to our new Sentry Token format