### PR TITLE
chore: update trufflehog and pin actions

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Enforce License Compliance'
-        uses: getsentry/action-enforce-license-compliance@main
+        uses: getsentry/action-enforce-license-compliance@4fae092d42cc91cdfa447eb5b0987cbecfdb07c6 # main
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.5.0
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
 
       - name: Pin Trufflehog to a know good release
         id: trufflehog_release
@@ -29,8 +29,8 @@ jobs:
         #   echo "latest_tag_name=$LATEST_TAG_NAME" >> "$GITHUB_OUTPUT"
         #   echo "latest_release=$LATEST_RELEASE" >> "$GITHUB_OUTPUT"
         run: |
-          echo "latest_tag_name=v3.88.11" >> "$GITHUB_OUTPUT"
-          echo "latest_release=3.88.11" >> "$GITHUB_OUTPUT"
+          echo "latest_tag_name=v3.88.20" >> "$GITHUB_OUTPUT"
+          echo "latest_release=3.88.20" >> "$GITHUB_OUTPUT"
 
       - name: Download and verify TruffleHog release
         run: |


### PR DESCRIPTION
- Update TruffleHog to 3.88.20 (includes the new Sentry token formats!)
- Pin version references GitHub Actions to defend against dependency attacks. 