### PR TITLE
Add second destination for secret-scan output

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -61,12 +61,16 @@ jobs:
           else
             trufflehog git file://. --only-verified --github-actions --fail --exclude-detectors="datadogtoken"
           fi
-      - name: Send Alert to Panther
+      - name: Send Alert to SIEM
         id: alert
         run: |
           if [[ -n "${{vars.SECRET_SCAN_PANTHER_WEBHOOK_URL}}" ]]; then
             curl "${{vars.SECRET_SCAN_PANTHER_WEBHOOK_URL}}" \
               --header "Authorization: Bearer ${{ secrets.SECRET_SCAN_PANTHER_WEBHOOK_HEADER }}" \
+              --data '{"event":"github_secret_scanning", "status":"${{steps.scan.outcome}}", "createdAt":"${{ github.event.pull_request.created_at }}", "repo":"${{ github.repository }}","pull_request":"https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}","actor":"${{ github.event.pull_request.user.login }}"}'
+          fi
+          if [[ -n "${{vars.SECRET_SCAN_SIEM_WEBHOOK_URL}}" ]]; then
+            curl "${{vars.SECRET_SCAN_SIEM_WEBHOOK_URL}}" \
               --data '{"event":"github_secret_scanning", "status":"${{steps.scan.outcome}}", "createdAt":"${{ github.event.pull_request.created_at }}", "repo":"${{ github.repository }}","pull_request":"https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}","actor":"${{ github.event.pull_request.user.login }}"}'
           fi
       - name: Fail workflow if secret detected


### PR DESCRIPTION
Dual syncing with our old and new SIEM before deprecating the old. Don't merge until the new org-wide variable is added. 