### PR TITLE
chore: update trufflehog to 3.89.2

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,25 +1,19 @@
 name: Secret Scan
-
 on: [pull_request, merge_group]
-
 jobs:
   secret-scan:
     name: Secret Scan
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
-
     outputs:
       latest_release: ${{ steps.trufflehog_release.outputs.latest_release }}
       latest_tag_name: ${{ steps.trufflehog_release.outputs.latest_tag_name }}
-
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
       - name: Install Cosign
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
-
       - name: Pin Trufflehog to a know good release
         id: trufflehog_release
         shell: bash
@@ -29,9 +23,8 @@ jobs:
         #   echo "latest_tag_name=$LATEST_TAG_NAME" >> "$GITHUB_OUTPUT"
         #   echo "latest_release=$LATEST_RELEASE" >> "$GITHUB_OUTPUT"
         run: |
-          echo "latest_tag_name=v3.88.25" >> "$GITHUB_OUTPUT"
-          echo "latest_release=3.88.25" >> "$GITHUB_OUTPUT"
-
+          echo "latest_tag_name=v3.89.2" >> "$GITHUB_OUTPUT"
+          echo "latest_release=3.89.2" >> "$GITHUB_OUTPUT"
       - name: Download and verify TruffleHog release
         run: |
           curl -sLO https://github.com/trufflesecurity/trufflehog/releases/download/${{ steps.trufflehog_release.outputs.latest_tag_name }}/trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt
@@ -46,12 +39,10 @@ jobs:
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 
           sha256sum --ignore-missing -c trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_checksums.txt
-
       - name: Extract TruffleHog
         run: |
           tar xzf trufflehog_${{ steps.trufflehog_release.outputs.latest_release }}_linux_amd64.tar.gz -C /usr/local/bin
           chmod +x /usr/local/bin/trufflehog
-
       - name: Run TruffleHog scan
         continue-on-error: true
         id: scan


### PR DESCRIPTION
Update trufflehog to the latest available version, 3.89.2.