### PR TITLE
feat(warden): Upload findings to GCS via Workload Identity Federation

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
         contents: read
+        id-token: write
     env:
       WARDEN_ANTHROPIC_API_KEY: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
       WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
@@ -24,7 +25,29 @@ jobs:
           private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }} # access to all repos, cause this is triggered on org level
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+        with:
+          workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+          service_account: gha-warden@sac-prod-sa.iam.gserviceaccount.com
+
       - uses: getsentry/warden@v0
+        id: warden
         continue-on-error: true # throw no error for now
         with:
           github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Rename findings file with timestamp
+        id: rename-findings
+        if: always()
+        run: |
+          DEST="$RUNNER_TEMP/$(date -u +%Y-%m-%dT%H%M%SZ).json"
+          cp "${{ steps.warden.outputs.findings-file }}" "$DEST"
+          echo "path=$DEST" >> "$GITHUB_OUTPUT"
+
+      - name: Upload findings to GCS
+        uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2
+        if: always()
+        with:
+          path: ${{ steps.rename-findings.outputs.path }}
+          destination: warden-logs/${{ github.repository }}

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -49,6 +49,7 @@ jobs:
           echo "path=$DEST" >> "$GITHUB_OUTPUT"
 
       - name: Upload findings to GCS
+        continue-on-error: true
         uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2
         if: always() && steps.rename-findings.outputs.path != ''
         with:

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -25,29 +25,32 @@ jobs:
           private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }} # access to all repos, cause this is triggered on org level
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-        with:
-          workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
-          service_account: gha-warden@sac-prod-sa.iam.gserviceaccount.com
-
       - uses: getsentry/warden@v0
         id: warden
         continue-on-error: true # throw no error for now
         with:
           github-token: ${{ steps.app-token.outputs.token }}
 
+      - name: Authenticate to Google Cloud
+        continue-on-error: true
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+        with:
+          workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+          service_account: gha-warden@sac-prod-sa.iam.gserviceaccount.com
+
       - name: Rename findings file with timestamp
         id: rename-findings
-        if: always()
+        if: always() && steps.warden.outputs.findings-file != ''
+        env:
+          FINDINGS_FILE: ${{ steps.warden.outputs.findings-file }}
         run: |
           DEST="$RUNNER_TEMP/$(date -u +%Y-%m-%dT%H%M%SZ).json"
-          cp "${{ steps.warden.outputs.findings-file }}" "$DEST"
+          cp "$FINDINGS_FILE" "$DEST"
           echo "path=$DEST" >> "$GITHUB_OUTPUT"
 
       - name: Upload findings to GCS
         uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2
-        if: always()
+        if: always() && steps.rename-findings.outputs.path != ''
         with:
           path: ${{ steps.rename-findings.outputs.path }}
           destination: warden-logs/${{ github.repository }}


### PR DESCRIPTION
Upload warden structured findings JSON to a GCS bucket (`warden-logs`) after each PR scan, using GCP Workload Identity Federation for authentication.

This enables downstream analysis of warden findings — specifically to determine whether linters or other static analysis tools could catch issues that warden currently finds.

Files are stored at `gs://warden-logs/<org>/<repo>/<timestamp>.json`.

**GCP prerequisites:**
- Service account `gha-warden@sac-prod-sa.iam.gserviceaccount.com` needs workload identity pool binding for this repo
- Service account needs `roles/storage.objectCreator` on the `warden-logs` bucket


Agent transcript: https://claudescope.sentry.dev/share/UvprGlpQKb1AA0zn-RInMqbwPfnbkAVnYTXlRLDB6zY