### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -25,7 +25,7 @@ jobs:
           private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }} # access to all repos, cause this is triggered on org level
 
-      - uses: getsentry/warden@v0
+      - uses: getsentry/warden@34257abaeda3b030eb45a0971060d509ce0fea51 # v0
         id: warden
         continue-on-error: true # throw no error for now
         with:


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)