### PR TITLE
fix(warden): Disable Warden if secrets are not available

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -5,8 +5,18 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  check-permissions:
+    runs-on: ubuntu-latest
+    outputs:
+      HAS_SECRETS: ${{ steps.check.outputs.HAS_SECRETS }}
+    steps:
+      - run: echo "HAS_SECRETS=${{ secrets.WARDEN_PRIVATE_KEY != '' }}" >> "$GITHUB_OUTPUT"
+        id: check
+
   warden:
     runs-on: ubuntu-latest
+    needs: check-permissions
+    if: ${{ needs.check-permissions.outputs.HAS_SECRETS == 'true' }}
     permissions:
         contents: read
         id-token: write


### PR DESCRIPTION
For contributors outside the getsentry org, secrets are not available, which causes this job to fail. Disable it for now to prevent false positives.

(I think this repo is missing the legal boilerplate etc by default? Either way, copied over from another PR:)

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.