### PR TITLE
ci(warden): Add global security review baseline

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -18,6 +18,12 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Checkout Org GitHub Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.repository_owner }}/.github
+          path: .warden-org
+
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-token
         with:
@@ -30,6 +36,7 @@ jobs:
         continue-on-error: true # throw no error for now
         with:
           github-token: ${{ steps.app-token.outputs.token }}
+          base-config-path: .warden-org/warden.toml
 
       - name: Authenticate to Google Cloud
         continue-on-error: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Instructions
+
+## Repository
+- Org-level GitHub metadata repository for Getsentry.
+- Edit org profile content in `profile/README.md`.
+- Edit GitHub configuration under `.github/`; root files cover shared policies and metadata.
+
+## Package Manager
+- No package manager, lockfile, or local build system is configured.
+
+## File-Scoped Commands
+| Task | Command |
+|------|---------|
+| YAML syntax | `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/<file>.yml` |
+| Whitespace | `git diff --check -- <path>` |
+
+## GitHub Actions
+- Org-wide Warden base config lives in `warden.toml`.
+- Preserve existing third-party action pinning to full commit SHAs when editing workflows.
+- Keep version comments beside pinned actions when present.
+- `secret-scan.yml` reports to SIEM before failing detected secret scans; keep that flow intact.
+
+## Security
+- Follow `SECURITY.md` for vulnerability reporting text.
+- Use inert placeholder values in examples; do not add realistic tokens or secrets.
+
+## Commit Attribution
+AI commits MUST include:
+```
+Co-Authored-By: (the agent's name and attribution byline)
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/warden.toml
+++ b/warden.toml
@@ -1,0 +1,14 @@
+version = 1
+
+[defaults]
+reportOn = "medium"
+failOn = "off"
+failCheck = false
+requestChanges = false
+
+[[skills]]
+name = "security-review"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]


### PR DESCRIPTION
Add an org-wide Warden baseline that runs the built-in security-review skill for pull requests across the organization. The global workflow now checks out this .github repo as the base config source and passes warden.toml to Warden's native layered config support.

**Warden Baseline**

The new root warden.toml reports medium-and-up security findings while keeping the rollout non-blocking with failOn disabled and failCheck false.

**Agent Instructions**

Add a concise AGENTS.md for this metadata repository and keep CLAUDE.md as a symlink for compatibility.

Refs getsentry/warden#279