### PR TITLE
ci(warden): Use Pi runtime for org baseline

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -1,6 +1,8 @@
 version = 1
 
 [defaults]
+runtime = "pi"
+model = "anthropic/claude-sonnet-4-6"
 reportOn = "medium"
 failOn = "off"
 failCheck = false


### PR DESCRIPTION
Move the org-wide Warden baseline onto the Pi runtime and pin it to Warden's documented Anthropic model selector. This keeps the shared security review config aligned with the current Warden action runtime and avoids invalid model selectors in CI.

Refs getsentry/warden#318