### PR TITLE
ci(warden): Report low-severity findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+dist/
+node_modules/

--- a/warden.toml
+++ b/warden.toml
@@ -3,7 +3,7 @@ version = 1
 [defaults]
 runtime = "pi"
 model = "anthropic/claude-sonnet-4-6"
-reportOn = "medium"
+reportOn = "low"
 failOn = "off"
 failCheck = false
 requestChanges = false


### PR DESCRIPTION
Lower the org-wide Warden reporting threshold so low-severity findings are included in reports. This also ignores local Node output directories that can be produced by tooling but should not be checked in.

**Warden Reporting**

`warden.toml` now reports findings at `low` and above while leaving failure behavior disabled.

**Generated Output**

The root `.gitignore` now excludes `dist/` and `node_modules/`.