### PR TITLE
ci(warden): switch to analyze/report split workflow

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -41,12 +41,21 @@ jobs:
           private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }} # access to all repos, cause this is triggered on org level
 
-      - uses: getsentry/warden@v0
-        id: warden
-        continue-on-error: true # throw no error for now
+      - name: Analyze
+        id: warden-analyze
+        uses: getsentry/warden@v0
+        continue-on-error: true
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          mode: analyze
           base-config-path: .warden-org/warden.toml
+
+      - name: Report
+        if: always() && steps.warden-analyze.outputs.findings-file != ''
+        uses: getsentry/warden@v0
+        with:
+          mode: report
+          findings-file: ${{ steps.warden-analyze.outputs.findings-file }}
+          github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Authenticate to Google Cloud
         continue-on-error: true
@@ -57,9 +66,9 @@ jobs:
 
       - name: Rename findings file with timestamp
         id: rename-findings
-        if: always() && steps.warden.outputs.findings-file != ''
+        if: always() && steps.warden-analyze.outputs.findings-file != ''
         env:
-          FINDINGS_FILE: ${{ steps.warden.outputs.findings-file }}
+          FINDINGS_FILE: ${{ steps.warden-analyze.outputs.findings-file }}
         run: |
           DEST="$RUNNER_TEMP/$(date -u +%Y-%m-%dT%H%M%SZ).json"
           cp "$FINDINGS_FILE" "$DEST"

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -45,14 +45,14 @@ jobs:
 
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-token
-        if: always() && steps.warden-analyze.outputs.findings-file != ''
+        if: ${{ always() && steps.warden-analyze.outputs.findings-file != '' }}
         with:
           app-id: ${{ secrets.WARDEN_APP_ID }}
           private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }} # access to all repos, cause this is triggered on org level
 
       - name: Report
-        if: always() && steps.warden-analyze.outputs.findings-file != ''
+        if: ${{ always() && steps.warden-analyze.outputs.findings-file != '' }}
         uses: getsentry/warden@v0
         continue-on-error: true
         with:
@@ -61,7 +61,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Authenticate to Google Cloud
-        if: always() && steps.warden-analyze.outputs.findings-file != ''
+        if: ${{ always() && steps.warden-analyze.outputs.findings-file != '' }}
         continue-on-error: true
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
@@ -70,7 +70,7 @@ jobs:
 
       - name: Rename findings file with timestamp
         id: rename-findings
-        if: always() && steps.warden-analyze.outputs.findings-file != ''
+        if: ${{ always() && steps.warden-analyze.outputs.findings-file != '' }}
         env:
           FINDINGS_FILE: ${{ steps.warden-analyze.outputs.findings-file }}
         run: |
@@ -81,7 +81,7 @@ jobs:
       - name: Upload findings to GCS
         continue-on-error: true
         uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2
-        if: always() && steps.rename-findings.outputs.path != ''
+        if: ${{ always() && steps.rename-findings.outputs.path != '' }}
         with:
           path: ${{ steps.rename-findings.outputs.path }}
           destination: warden-logs/${{ github.repository }}

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -19,6 +19,7 @@ jobs:
     if: ${{ needs.check-permissions.outputs.HAS_SECRETS == 'true' }}
     permissions:
         contents: read
+        pull-requests: read
         id-token: write
     env:
       WARDEN_ANTHROPIC_API_KEY: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
@@ -34,13 +35,6 @@ jobs:
           repository: ${{ github.repository_owner }}/.github
           path: .warden-org
 
-      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: app-token
-        with:
-          app-id: ${{ secrets.WARDEN_APP_ID }}
-          private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }} # access to all repos, cause this is triggered on org level
-
       - name: Analyze
         id: warden-analyze
         uses: getsentry/warden@v0
@@ -49,15 +43,25 @@ jobs:
           mode: analyze
           base-config-path: .warden-org/warden.toml
 
+      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        if: always() && steps.warden-analyze.outputs.findings-file != ''
+        with:
+          app-id: ${{ secrets.WARDEN_APP_ID }}
+          private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }} # access to all repos, cause this is triggered on org level
+
       - name: Report
         if: always() && steps.warden-analyze.outputs.findings-file != ''
         uses: getsentry/warden@v0
+        continue-on-error: true
         with:
           mode: report
           findings-file: ${{ steps.warden-analyze.outputs.findings-file }}
           github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Authenticate to Google Cloud
+        if: always() && steps.warden-analyze.outputs.findings-file != ''
         continue-on-error: true
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -52,7 +52,7 @@ jobs:
           owner: ${{ github.repository_owner }} # access to all repos, cause this is triggered on org level
 
       - name: Report
-        if: ${{ always() && steps.warden-analyze.outputs.findings-file != '' }}
+        if: ${{ always() && steps.warden-analyze.outputs.findings-file != '' && steps.app-token.outcome == 'success' }}
         uses: getsentry/warden@v0
         continue-on-error: true
         with:


### PR DESCRIPTION
Splits the single `getsentry/warden@v0` step into separate `Analyze` and `Report` steps using the `mode` input added in warden 0.38.0.

**What changed:**
- `Analyze` step runs with `mode: analyze` — no write token, uses `GITHUB_TOKEN` with `pull-requests: read` (added to permissions block) to read PR diffs
- App token is created *after* analyze, scoped to when a findings file was produced — keeping the high-privilege write token out of the analysis phase
- `Report` step runs with `mode: report`, receives the findings file and app token for write access; `continue-on-error: true` preserves original behavior
- `Authenticate to Google Cloud` now has an explicit `if: always() && findings-file != ''` guard so GCS upload still runs even when Report fails
- Findings rename/upload references `steps.warden-analyze` (same semantics, updated step id)

**Requires:** warden `v0` tag pointing to 0.38.0+

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0ACFA5JBDX%3A1781044169.668889%22)