### PR TITLE
ci(warden): Preserve base config in report mode

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -59,6 +59,7 @@ jobs:
           mode: report
           findings-file: ${{ steps.warden-analyze.outputs.findings-file }}
           github-token: ${{ steps.app-token.outputs.token }}
+          base-config-path: .warden-org/warden.toml
 
       - name: Authenticate to Google Cloud
         if: ${{ always() && steps.warden-analyze.outputs.findings-file != '' }}


### PR DESCRIPTION
The Warden report step now receives the same base config path as analyze mode. This keeps split analyze/report runs replaying findings against the same trigger set, instead of rejecting analyze output when the repo-local config differs from the org baseline.

The change is limited to the shared Warden workflow wiring.