### PR TITLE
add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       prefix: "ci"
     labels:
       - "dependencies"
-    reviewers:
-      - "getsentry/dev-infra"
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "getsentry/dev-infra"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Otherwise action bumps have been unnoticed in this repo. Will get sent to devinfra