### PR TITLE
meta(warden): Use Grok 4.5 through OpenRouter

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -2,7 +2,7 @@ version = 1
 
 [defaults]
 runtime = "pi"
-model = "anthropic/claude-sonnet-4-6"
+model = "openrouter/x-ai/grok-4.5"
 reportOn = "low"
 failOn = "off"
 failCheck = false


### PR DESCRIPTION
Warden security reviews now use Grok 4.5 through OpenRouter instead of Claude Sonnet 4.6. The provider-qualified selector matches Pi's OpenRouter catalog and uses the existing WARDEN_OPENROUTER_API_KEY workflow credential.