### PR TITLE
Exclude false positive lob detector

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -65,9 +65,9 @@ jobs:
         id: scan
         run: |
           if [ -e .secret_scan_ignore ]; then
-            trufflehog git file://. --only-verified --github-actions --fail --exclude-paths=.secret_scan_ignore --exclude-detectors="datadogtoken"
+            trufflehog git file://. --only-verified --github-actions --fail --exclude-paths=.secret_scan_ignore --exclude-detectors="datadogtoken,lob"
           else
-            trufflehog git file://. --only-verified --github-actions --fail --exclude-detectors="datadogtoken"
+            trufflehog git file://. --only-verified --github-actions --fail --exclude-detectors="datadogtoken,lob"
           fi
       - name: Send Alert to SIEM
         id: alert


### PR DESCRIPTION
Ton of Lob "verified" results from a recent change in trufflehog, they're all FPs. Removing lob as a detector in all secret scans since we're not using them anyway. Some of the files with FPs in it:
- test_organization_access_request_details
- test_proxied_cell_headers_gateway_marker
- test_image_block_for_endpoint_regression
- test_feature_with_experiment_mode_simple

attributable to this change https://github.com/trufflesecurity/trufflehog/pull/4971

<img width="495" height="796" alt="image" src="https://github.com/user-attachments/assets/abc430d6-e289-426e-b2d7-5a14cee55a9d" />
