### PR TITLE
ci(warden): Pass Warden Service URL and token to the review job

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -16,6 +16,8 @@ jobs:
       WARDEN_OPENROUTER_API_KEY: ${{ secrets.WARDEN_OPENROUTER_API_KEY }}
       WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
       WARDEN_SENTRY_DSN: ${{ secrets.WARDEN_SENTRY_DSN }}
+      WARDEN_SERVICE_URL: ${{ vars.WARDEN_SERVICE_URL }}
+      WARDEN_SERVICE_TOKEN: ${{ secrets.WARDEN_SERVICE_TOKEN }}
     steps:
       - name: Check Warden credentials
         env:


### PR DESCRIPTION
Expose the org-wide `WARDEN_SERVICE_URL` variable and `WARDEN_SERVICE_TOKEN` secret to the Warden job so the action can reach Warden Service.

The URL is read from the `vars` context rather than `env`. Org and repository variables are only available through `vars`; reading it from `env` would self-reference the job's own `env` block and silently resolve to an empty string.

Two things worth a reviewer's eye:

- **Access policy.** If the org variable/secret were created with "Selected repositories," every repo relying on this reusable workflow needs to be in the access list. Otherwise both expressions resolve to empty with no error and the action just sees unset env vars.
- **No fail-fast.** Unlike `WARDEN_OPENROUTER_API_KEY`, which the "Check Warden credentials" step gates on with a `!= ''` check, a missing service URL or token will not fail the job. Left as-is deliberately so Warden reviews keep working if Warden Service is unconfigured or down, but happy to add a check if we would rather know loudly.

Draft until the org-level access policy is confirmed to cover the repos using this workflow.