### PR TITLE
ci(warden): Use Kimi K3 for Warden reviews

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -14,7 +14,7 @@ jobs:
         id-token: write
     env:
       WARDEN_OPENROUTER_API_KEY: ${{ secrets.WARDEN_OPENROUTER_API_KEY }}
-      WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
+      WARDEN_MODEL: openrouter/moonshotai/kimi-k3
       WARDEN_SENTRY_DSN: ${{ secrets.WARDEN_SENTRY_DSN }}
       WARDEN_SERVICE_URL: ${{ vars.WARDEN_SERVICE_URL }}
       WARDEN_SERVICE_TOKEN: ${{ secrets.WARDEN_SERVICE_TOKEN }}

--- a/warden.toml
+++ b/warden.toml
@@ -2,7 +2,7 @@ version = 1
 
 [defaults]
 runtime = "pi"
-model = "openrouter/x-ai/grok-4.5"
+model = "openrouter/moonshotai/kimi-k3"
 reportOn = "low"
 failOn = "off"
 failCheck = false
@@ -33,7 +33,7 @@ ignorePaths = [
 ]
 
 [defaults.agent]
-effort = "high"
+effort = "max"
 
 [defaults.auxiliary]
 model = "openrouter/openai/gpt-5.6-luna"


### PR DESCRIPTION
Move the org-wide Warden security review from Grok 4.5 at high effort to Kimi K3 at max effort.

Also set the shared workflow fallback explicitly to Kimi K3. Repository-local skills that omit a model previously fell through to the Pi default, K2.6. They will now use K3 while still respecting any model or effort configured by the repository.

In the latest seven-day telemetry window, 128 of 133 workflows over 20 minutes were K2.6-only, and 85 K2.6 traces contained a provider error. The Sentry vulnerability corpus also put K3 within one known finding of Grok while using about half the total cost.

Auxiliary calls remain on Luna. Repository-local skills that omit an effort continue to use the Pi default effort; the workflow cannot set that separately today.